### PR TITLE
Update casing of Microsoft.Net.Compilers.netcore

### DIFF
--- a/src/Microsoft.NuGet.Build.Tasks/project.json
+++ b/src/Microsoft.NuGet.Build.Tasks/project.json
@@ -20,7 +20,7 @@
         "Microsoft.Build.Utilities.Core": "0.1.0-preview-00024-160610",
         "Microsoft.Build.Targets": "0.1.0-preview-00024-160610",
         "Microsoft.Build": "0.1.0-preview-00024-160610",
-        "Microsoft.Net.Compilers.NetCore": "1.3.0",
+        "Microsoft.Net.Compilers.netcore": "1.3.0",
         "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
         "Microsoft.Cci": "4.0.0-rc3-24128-00",
         "Microsoft.Composition": "1.0.30"


### PR DESCRIPTION
Our code is broken with the latest NuGet version since this does not have the correct casing.
